### PR TITLE
Added missing configuration(Infectious Section), Fixed bat running path

### DIFF
--- a/Scenarios/Malaria/Full_Malaria_Model/config.json
+++ b/Scenarios/Malaria/Full_Malaria_Model/config.json
@@ -18,7 +18,7 @@
     "Antibody_IRBC_Kill_Rate": 1.5,
     "Antibody_Memory_Level": 0.225,
     "Antibody_Stimulation_C50": 10,
-    "Antigen_Switch_Rate": 2e-09,
+    "Antigen_Switch_Rate": 2e-9,
     "Base_Air_Temperature": 22.0,
     "Base_Gametocyte_Fraction_Male": 0.2,
     "Base_Gametocyte_Mosquito_Survival_Rate": 0.01,
@@ -45,9 +45,7 @@
     "Death_Rate_Dependence": "NONDISEASE_MORTALITY_BY_AGE_AND_GENDER",
     "Default_Geography_Initial_Node_Population": 1000,
     "Default_Geography_Torus_Size": 10,
-    "Demographics_Filenames": [
-      "Namawala_single_node_demographics.json"
-    ],
+    "Demographics_Filenames": ["Namawala_single_node_demographics.json"],
     "Egg_Hatch_Delay_Distribution": "NO_DELAY",
     "Egg_Hatch_Density_Dependence": "NO_DENSITY_DEPENDENCE",
     "Egg_Saturation_At_Oviposition": "SATURATION_AT_OVIPOSITION",
@@ -102,7 +100,11 @@
     "Incubation_Period_Constant": 7,
     "Incubation_Period_Distribution": "CONSTANT_DISTRIBUTION",
     "Individual_Sampling_Type": "TRACK_ALL",
-    "Infection_Updates_Per_Timestep": 24,    
+    "Infection_Updates_Per_Timestep": 24,
+    "Infectivity_Exponential_Baseline": 0.1,
+    "Infectivity_Exponential_Delay": 90,
+    "Infectivity_Exponential_Rate": 45,
+    "Infectivity_Scale_Type": "EXPONENTIAL_FUNCTION_OF_TIME",
     "Innate_Immune_Variation_Type": "NONE",
     "Koppen_Filename": "",
     "Land_Temperature_Filename": "Namawala_single_node_land_temperature_daily.bin",
@@ -323,11 +325,7 @@
     "Transmission_Blocking_Immunity_Duration_Before_Decay": 90,
     "Vector_Larval_Rainfall_Mortality": "NONE",
     "Vector_Sampling_Type": "VECTOR_COMPARTMENTS_NUMBER",
-    "Vector_Species_Names": [
-      "arabiensis",
-      "funestus",
-      "gambiae"
-    ],
+    "Vector_Species_Names": ["arabiensis", "funestus", "gambiae"],
     "Vector_Species_Params": {
       "arabiensis": {
         "Acquire_Modifier": 1,

--- a/Scenarios/Malaria/Full_Malaria_Model/runEmod.bat
+++ b/Scenarios/Malaria/Full_Malaria_Model/runEmod.bat
@@ -1,2 +1,2 @@
-..\..\..\..\Eradication.exe --config config.json --input-path ..\..\..\..\Demographics_Files
+..\..\..\Eradication.exe --config config.json --input-path ..\..\..\Demographics_Files
 @pause


### PR DESCRIPTION
Error showed `While trying to parse json data for param/key >>> Infectivity_Scale_Type <<< in otherwise valid json segment...` when running malaria scenario in this example.
After adding this configuration:
 `"Infectivity_Scale_Type": "EXPONENTIAL_FUNCTION_OF_TIME"`
 into the `JSON` and fixed the path in the `runEmod.bat`, the error was fixed.